### PR TITLE
Add legal notice section and update legal notes for Mobile SDK compliance

### DIFF
--- a/LEGAL_NOTES.md
+++ b/LEGAL_NOTES.md
@@ -1,0 +1,29 @@
+# Legal notice
+
+The following legal terms (“Legal Notice”) apply to all use of the Tedee Mobile SDK. By accessing or using our SDK, you agree to these terms in full.
+
+**1. NO WARRANTIES; “AS-IS” BASIS**
+
+Tedee provides its SDK and all related content strictly on an “as-is” and “as-available” basis. To the fullest extent permitted by applicable law, Tedee disclaims all representations and warranties of any kind, whether express, implied, statutory or otherwise - including, without limitation, warranties of title, non-infringement, merchantability, fitness for a particular purpose, uninterrupted availability, accuracy, or those arising from course of dealing or usage of trade.
+
+**2. LIMITATION OF LIABILITY**
+
+Under no circumstances shall Tedee, its affiliates, officers, directors, employees or agents be liable for any indirect, incidental, special, consequential, punitive or exemplary damages—including, without limitation, lost profits, lost revenue, loss of data or business interruption—arising out of or in connection with your use of, or inability to use, the SDK, even if Tedee has been advised of the possibility of such damages.
+
+To the maximum extent permitted by law, Tedee’s total liability for any claim arising from or related to this SDK, whether in contract, tort (including negligence), strict liability or otherwise, is limited to the greater of (a) the fees you have actually paid to Tedee for use of the applicable SDK during the six months immediately preceding the event giving rise to liability, or (b) the re-supply of the SDK.
+
+**3. INDEMNIFICATION**
+
+You agree to defend, indemnify and hold harmless Tedee and its affiliates, officers, directors, employees and agents from and against any and all liabilities, damages, losses, claims, costs and expenses (including reasonable legal fees) arising out of or relating to: Your use of, or inability to use, the SDK; Your breach of this Legal Notice or any other agreement with Tedee; or Any content, data or materials you transmit to or through the SDK.
+
+**4. THIRD-PARTY CONTENT & SERVICES**
+
+The SDK may expose content or services owned by third parties. Tedee makes no representations or warranties whatsoever regarding the legality, accuracy, copyright compliance, or quality of any such third-party content or services. You bear all risks associated with your access to and use of third-party content through the SDK.
+
+**5. REGULATORY COMPLIANCE**
+
+You are solely responsible for ensuring your use of the SDK complies with all applicable laws, regulations, export controls, and third-party rights (including without limitation privacy, data protection, and intellectual property rights).
+
+**6. MODIFICATIONS; TERMINATION**
+
+Tedee may modify or discontinue, temporarily or permanently, all or part of the SDK at any time and without notice. You agree that Tedee will not be liable to you or any third party for any modification, suspension, or discontinuation of the SDK.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,10 @@ For any inquiries, feedback, or assistance, our iOS team is here to help. Reach 
 
 We're excited to witness the innovative solutions you create with the Tedee Mobile SDK! Happy coding! 🚀
 
-
 ### Credits
 
 This product includes software developed by the "Marcin Krzyzanowski" (http://krzyzanowskim.com/).
+
+### Legal Notice
+
+By using the Tedee Mobile SDK, you agree to the terms of the [LICENSE](./LICENSE.md) and the [LEGAL_NOTES](./LEGAL_NOTES.md). Please review these documents before integrating or distributing the SDK.


### PR DESCRIPTION
This PR adds a dedicated 'Legal Notice' section to the README and updates LEGAL_NOTES.md to refer to the Mobile SDK instead of the API. The legal notice is now clearly visible and linked from the main documentation, ensuring clarity and compliance for SDK users.